### PR TITLE
added basic plantuml translate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ poetry install
 ```
 
 ### PlantUML example
+
 Files of a single type can be "translated" to PlantUML diagrams. See the following example:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ export PATH=$PATH:$HOME/.local/bin
 poetry install
 ```
 
+### PlantUML example
+Files of a single type can be "translated" to PlantUML diagrams. See the following example:
+
+```shell
+janus translate --input-dir INPUT_DIR --output-dir OUTPUT_DIR --source-lang SOURCE_LANG --target-lang plantuml --prompt-template janus-llm/janus/prompts/templates/uml-diagram/
+```
+
+Please note that using plantuml as an input language in regular translation is very likely broken.
+
 ### Contributing
 
 See our [contributing pages](https://janus-llm.github.io/janus-llm/contributing.html)

--- a/janus/prompts/templates/uml-diagram/human.txt
+++ b/janus/prompts/templates/uml-diagram/human.txt
@@ -1,0 +1,25 @@
+Generate PlantUML code from the provided source code, considering:
+
+Class and method identification
+Visibility and access modifiers
+Inheritance, composition, and aggregation
+Associations and dependencies
+UML notation and conventions
+
+Adhere to PlantUML syntax and best practices. Provide the generated code and any necessary explanations or comments.
+
+If the given code is incomplete, assume it is translated elsewhere.
+If the given code is missing variable definitions, assume they are assigned elsewhere.
+If there are incomplete statements that haven't been closed out, assume they are closed out in other translations.
+If the code has comments, keep ALL of them.
+If it only consists of ONLY comments, assume the code that is represented by those comments is translated elsewhere.
+
+Some more things to remember:
+(1) follow standard styling practice for PlantUML
+(2) make sure the language is typed correctly
+(3) make sure to put the resultant code within triple backticks
+
+```
+{SOURCE_CODE}
+```
+

--- a/janus/utils/enums.py
+++ b/janus/utils/enums.py
@@ -474,6 +474,12 @@ LANGUAGES: Dict[str, Dict[str, str]] = {
         "url": "https://github.com/tree-sitter/tree-sitter-php",
         "example": "<?php\n// Hello, World!\necho 'Hello, World!';\n",
     },
+    "plantuml": {
+        "comment": "'",
+        "suffix": "puml",
+        "url": "",
+        "example": '@startuml\nclass Animal <<GENERAL>>\n@enduml\n',
+    },
     "pod": {
         "comment": "=",
         "suffix": "pod",


### PR DESCRIPTION
"SysML on Demo Code Base Using LLMs #91"

## Description

Using janus translate, with appropriate changes the language support / prompting, can allow for plantuml diagram files to be generated on a per file basis for a single already support language.

## Testing

Limited details are added to the README, but for visibility are also below:

Files of a single type can be "translated" to PlantUML diagrams. See the following example:

```shell
janus translate --input-dir INPUT_DIR --output-dir OUTPUT_DIR --source-lang SOURCE_LANG --target-lang plantuml --prompt-template janus-llm/janus/prompts/templates/uml-diagram/
```

Please note that using plantuml as an input language in regular translation is very likely broken.

## Issues

Related to #91 in ai-code-refactor

The example I generated:
<img width="1286" alt="Screenshot 2024-07-16 at 1 44 46 PM" src="https://github.com/user-attachments/assets/f94e719e-698f-4113-8137-fb390afebc78">

