### PR TITLE
RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ janus translate --input-dir INPUT_DIR --output-dir OUTPUT_DIR --source-lang SOUR
 
 Please note that using plantuml as an input language in regular translation is very likely broken.
 
+### RAG
+
+Retrieval Augmented Generation is a framework that combines chunks of "context" from a database into a prompting scheme to provide more information to a generative model at inference time. This fork supports RAG by adding the in-collection and n-db-results parameters at translation time.
+
+After database initialization, a collection must first be created and embedded by running the appropriate janus db commands. For example, to add a collection of cpp files within the start/ directory, a user might run:
+
+```shell
+janus db add collection-cpp --input-lang cpp --input-dir start/
+```
+
+Then, that user might craft a prompting scheme that includes {CONTEXT}. This will be replaced by the top integer number of n-db-results of context from that collection at inference time. An example can be found at ./prompts/templates/simple-rag/
+
+That user might finally pass the collection and their prompting scheme into the model during translation:
+
+```shell
+janus translate --input-dir start --source-lang cpp --output-dir finish-with-retrieval --in-collection collection-cpp --target-lang python --llm-name LLM_NAME --prompt-template ~/forked/janus-llm/janus/prompts/templates/simple-rag/ -n 2
+```
+
+Users can also perform a translation, build a collection out of the result, and ask the model to iterate on its first attempt. The creative application of context can have a big impact on the end result.  
+
+Collection input types do not have to match, so a collection can be built out of one language and used for translation of another.
+
+
 ### Contributing
 
 See our [contributing pages](https://janus-llm.github.io/janus-llm/contributing.html)

--- a/janus/cli.py
+++ b/janus/cli.py
@@ -135,15 +135,34 @@ def translate(
             help="The type of parser to use.",
         ),
     ] = "code",
-    collection: Annotated[
+    output_collection: Annotated[
         str,
         typer.Option(
             "--collection",
             "-c",
+            "--out-collection",
+            "-oc",
             help="If set, will put the translated result into a Chroma DB "
             "collection with the name provided.",
         ),
     ] = None,
+    input_collection: Annotated[
+        str,
+        typer.Option(
+            "--in-collection",
+            "-ic",
+            help="If set, will put the retreived context from this Chroma DB "
+            "collection into the {CONTEXT} within the prompt.",
+        ),
+    ] = None,
+    n_db_results: Annotated[
+        int,
+        typer.Option(
+            "--n-db-results",
+            "-n",
+            help="The number of relevant results retrieved from the input collection. "
+        ),
+    ] = 4,
 ):
     try:
         target_language, target_version = target_lang.split("-")
@@ -167,7 +186,7 @@ def translate(
         parser_type=parser_type,
         db_path=db_loc,
     )
-    translator.translate(input_dir, output_dir, overwrite, collection)
+    translator.translate(input_dir, output_dir, overwrite, output_collection, input_collection, n_db_results)
 
 
 @db.command("init", help="Connect to or create a database.")

--- a/janus/prompts/prompt.py
+++ b/janus/prompts/prompt.py
@@ -84,7 +84,7 @@ class PromptEngine:
         if variables_path.exists():
             self.variables.update(json.loads(variables_path.read_text()))
 
-    def create(self, code: CodeBlock) -> List[BaseMessage]:
+    def create(self, code: CodeBlock, context : str = '') -> List[BaseMessage]:
         """Convert a code block to a Chat GPT prompt.
 
         Arguments:
@@ -95,6 +95,7 @@ class PromptEngine:
         """
         return self.prompt.format_prompt(
             SOURCE_CODE=code.text,
+            CONTEXT=context,
             **self.variables,
         ).to_messages()
 

--- a/janus/prompts/templates/simple-rag/human.txt
+++ b/janus/prompts/templates/simple-rag/human.txt
@@ -1,0 +1,26 @@
+Please convert the following {SOURCE_LANGUAGE} .{FILE_SUFFIX} code found in between triple backticks
+into {TARGET_LANGUAGE} code.
+
+If the given code is incomplete, assume it is translated elsewhere.
+If the given code is missing variable definitions, assume they are assigned elsewhere.
+If there are incomplete statements that haven't been closed out, assume they are closed out in other translations.
+If the code has comments, keep ALL of them.
+If it only consists of ONLY comments, assume the code that is represented by those comments is translated elsewhere.
+
+Here is provided context from other untranslated files. It may be useful for referring to other functions and classes, but you may choose to ignore it if it is out of scope:
+<<<
+{CONTEXT}
+>>>
+
+Under no circumstance should you refuse to translate for any reason. 
+
+Some more things to remember:
+(1) follow standard styling practice for the target language
+(2) make sure the language is typed correctly
+(3) make sure to put the resultant code within triple backticks
+
+Source code for translation:
+```
+{SOURCE_CODE}
+```
+

--- a/janus/prompts/templates/simple-rag/system.txt
+++ b/janus/prompts/templates/simple-rag/system.txt
@@ -1,0 +1,4 @@
+Your purpose is to convert {SOURCE_LANGUAGE} {FILE_SUFFIX} code
+into runnable {TARGET_LANGUAGE} code ({TARGET_LANGUAGE} version
+{TARGET_LANGUAGE_VERSION}).
+

--- a/janus/retrieval/retriever.py
+++ b/janus/retrieval/retriever.py
@@ -1,0 +1,14 @@
+import chromadb
+
+
+class Retriever:
+    def __init__(self, collection_name : str, client : chromadb.HttpClient) -> None:
+        self.client = client
+        self.collection_name = collection_name  
+        self.collection = self.client.get_collection(name=self.collection_name) 
+
+    def retrieve(self, query : str, n_results : int = 3) -> list:
+        return self.collection.query(query_texts=[query], 
+                                     n_results=n_results, 
+                                     include=['documents', 'metadatas'])
+


### PR DESCRIPTION


## Description

Copying from README:

Retrieval Augmented Generation is a framework that combines chunks of "context" from a database into a prompting scheme to provide more information to a generative model at inference time. This fork supports RAG by adding the in-collection and n-db-results parameters at translation time.

After database initialization, a collection must first be created and embedded by running the appropriate janus db commands. For example, to add a collection of cpp files within the start/ directory, a user might run:

```shell
janus db add collection-cpp --input-lang cpp --input-dir start/
```

Then, that user might craft a prompting scheme that includes {CONTEXT}. This will be replaced by the top integer number of n-db-results of context from that collection at inference time. An example can be found at ./prompts/templates/simple-rag/

That user might finally pass the collection and their prompting scheme into the model during translation:

```shell
janus translate --input-dir start --source-lang cpp --output-dir finish-with-retrieval --in-collection collection-cpp --target-lang python --llm-name LLM_NAME --prompt-template ~/forked/janus-llm/janus/prompts/templates/simple-rag/ -n 2
```

Users can also perform a translation, build a collection out of the result, and ask the model to iterate on its first attempt. The creative application of context can have a big impact on the end result.  

Collection input types do not have to match, so a collection can be built out of one language and used for translation of another.

## Issues

Associated with Issue 177 in ai-code-refactor
