### PR TITLE
reduced metadata returned

### DIFF
--- a/janus/retrieval/retriever.py
+++ b/janus/retrieval/retriever.py
@@ -8,7 +8,10 @@ class Retriever:
         self.collection = self.client.get_collection(name=self.collection_name) 
 
     def retrieve(self, query : str, n_results : int = 3) -> list:
-        return self.collection.query(query_texts=[query], 
+        result = self.collection.query(query_texts=[query], 
                                      n_results=n_results, 
                                      include=['documents', 'metadatas'])
+        result_filenames = [entry['filename'] for entry in result['metadatas'][0]]
+        names_and_documents = tuple(zip(result_filenames, result['documents'][0]))
+        return names_and_documents
 


### PR DESCRIPTION


## Description

The metadata janus includes by default is rather verbose. We wanted to reduce this metadata passed in context to only the document's filename instead of other peripheral data like nonsense ids and hashes that could in no way help with generation.

This change prevents unnecessary info from being passed down the line during prompting. We hope it will improve RAG translation quality.

## Testing

Test as you might with last RAG PR

## Issues

Related to RAG issue in ai-code-refactor.
