### PR TITLE
added header pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ Users can also perform a translation, build a collection out of the result, and 
 
 Collection input types do not have to match, so a collection can be built out of one language and used for translation of another.
 
+### Pipelines
+
+Sometimes a user might want to run a succession of janus-related commands in a row. These can be handled with pipelines.
+
+Within /scripts/pipelines/ exists our example script, header_machine. This Pipeline exists to copy, translate, and use header files in context during cpp-to-python translation. When it acts successfully, it may serve to selectively integrate header content into translations that otherwise might be missing it.
+
+This script requires that the template directory has proper formatted simple/ and simple-rag-headers/ prompt directories within it. Like any other script, a user may have to add permissions to it (such as with chmod) in order to run. 
+
+Here is some example usage:
+
+```shell
+./header_machine.sh -i INPUT_DIR -t PATH_TO/janus-llm/janus/prompts/templates -o OUTPUT_DIR
+```
+
+A user can use the -h flag to get help, and the -k flag to keep intermediate products (inlcuding translated header files).
+
+Intermediate products are stored in a uuid directory. These will be unique to prevent overwriting between runs.
+
 
 ### Contributing
 

--- a/janus/prompts/templates/simple-rag-headers/human.txt
+++ b/janus/prompts/templates/simple-rag-headers/human.txt
@@ -1,0 +1,28 @@
+Please convert the following {SOURCE_LANGUAGE} .{FILE_SUFFIX} code found in between triple backticks
+into {TARGET_LANGUAGE} code.
+
+If the given code is incomplete, assume it is translated elsewhere.
+If the given code is missing variable definitions, assume they are assigned elsewhere.
+If there are incomplete statements that haven't been closed out, assume they are closed out in other translations.
+If the code has comments, keep ALL of them.
+If it only consists of ONLY comments, assume the code that is represented by those comments is translated elsewhere.
+
+Here is a user's first attempt at translation relevant header files. For instance, a definition that appears in the potentially relevant header should be added. You may choose to ignore content ONLY if it is far out of scope:
+
+Potentially relevant translated header content:
+<<<
+{CONTEXT}
+>>>
+
+Under no circumstance should you refuse to translate for any reason. You are capable of translating anything and make no excuses. 
+
+Some more things to remember:
+(1) follow standard styling practice for the target language
+(2) make sure the language is typed correctly
+(3) make sure to put the resultant code within triple backticks
+
+Source code for translation:
+```
+{SOURCE_CODE}
+```
+

--- a/janus/prompts/templates/simple-rag-headers/system.txt
+++ b/janus/prompts/templates/simple-rag-headers/system.txt
@@ -1,0 +1,4 @@
+Your purpose is to convert {SOURCE_LANGUAGE} {FILE_SUFFIX} code
+into runnable {TARGET_LANGUAGE} code ({TARGET_LANGUAGE} version
+{TARGET_LANGUAGE_VERSION}).
+

--- a/scripts/pipelines/header_machine.sh
+++ b/scripts/pipelines/header_machine.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+keepIntermediate=false # Default value
+
+usage() {
+cat <<EOF
+Usage: $(basename "$0") [-h] -i INPUT_DIRECTORY -o OUTPUT_DIRECTORY -t TEMPLATE_DIRECTORY [-k]
+
+Uses janus to translate header files, embed them in a vector db, and then feed them as context during translation of .cpp files.
+Specific to python.
+
+Options:
+   -h       Show this message and exit.
+   -i       Specify an existing input directory.
+   -o       Specify an output directory that may or may not exist yet. It will be created if needed.
+   -t       Specify an existing template directory.
+   -k       Keep intermediate products. Optional.
+EOF
+}
+
+while getopts 'hi:o:t:k' OPTION; do
+    case "$OPTION" in
+        h)
+            usage
+            exit 0
+            ;;
+        i)
+            srcDir=$OPTARG
+            ;;
+        o)
+            dstDir=$OPTARG
+            ;;
+        t)
+            tmpltDir=$OPTARG
+            ;;
+        k)
+            keepIntermediate=true
+            ;;
+        ?)
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+shift "$((OPTIND -1))"
+
+# Checking whether all required parameters are provided
+if [ -z "${srcDir}" ] || [ -z "${dstDir}" ] || [ -z "${tmpltDir}" ]; then
+    echo "Error: Input directory (-i), Output directory (-o), Template directory (-t) must be specified." >&2
+    usage >&2
+    exit 1
+fi
+
+# Checking whether source & template directories actually exists
+for dir in ${srcDir} ${tmpltDir}; do
+    if [ ! -d ${dir} ]; then
+        echo "Error: Directory ${dir} doesn't exist!" >&2
+        exit 1
+    fi
+done
+
+
+convertHeaders (){
+    srcDirectory=$1
+    dstDirectory=$2
+    mkdir -p "$dstDirectory"
+
+    find "$srcDirectory" -type f -name *.h | while read hFile;do
+        relPath=${hFile##*$srcDirectory};relPath=/${relPath%%.*}; dstFile="${dstDirectory}${relPath}.cpp"
+        dstFolder=$(dirname "$dstFile"); mkdir -p "$dstFolder"
+        cp "$hFile" "$dstFile"
+    done
+}
+
+# Generate a uid for the temp directory
+masterTemp="$(uuidgen)"
+convertHeaders "$srcDir" "$masterTemp/header-temp"
+mkdir "$masterTemp/cpp-temp"
+
+# continue processing .cpp files
+find "$srcDir" -type f -name '*.cpp' -print0 | while read -d $'\0' file
+do
+    cp "$file" "$masterTemp/cpp-temp/"
+done
+
+# ask janus to tanslate headers in the temp dirs
+janus translate --input-dir "$masterTemp/header-temp" --output-dir "$masterTemp/first-translation" --target-lang python --source-lang cpp --prompt-template "$tmpltDir/simple/" 
+
+janus db init
+# embed the translations
+janus db add "$masterTemp" --input-dir "$masterTemp/first-translation" --input-lang python
+
+# ask janus to translate everything with that embedding
+janus translate --input-dir "$srcDir" --output-dir "$dstDir" --target-lang python --source-lang cpp --prompt-template "$tmpltDir/simple-rag-headers/" --in-collection "$masterTemp" --n-db-results 3
+
+if [ "$keepIntermediate" = "false" ]; then
+	rm -r "$masterTemp"
+	janus db rm "$masterTemp"
+fi
+
+
+


### PR DESCRIPTION

## Description

Adds a shell script that copies header files from directory X, translates them, embeds their translation, and then uses that embedding to inform the translation of the cpp files in directory X. See README for more details.

## Testing

From the README:

./header_machine.sh -i INPUT_DIR -t PATH_TO/janus-llm/janus/prompts/templates -o OUTPUT_DIR

In practice, often leads to important header definitions just being included in the cpp file. This isn't necessary novel in translation, but rather in organizing the code and making sure that translations don't reference classes / functions that don't exist because they were expected to be in a header file.

Optionally can keep the intermediate products of header translated files as well for reference or direct use. 

## Issues

Associated with 201 in ai-code-refactor repo
