### PR TITLE
Add PlantUML and H languages

### DIFF
--- a/janus/prompts/templates/uml-rag/human.txt
+++ b/janus/prompts/templates/uml-rag/human.txt
@@ -1,0 +1,26 @@
+Please convert the following {SOURCE_LANGUAGE} .{FILE_SUFFIX} code found in between triple backticks
+into {TARGET_LANGUAGE} code.
+
+If the given code is incomplete, assume it is translated elsewhere.
+If the given code is missing variable definitions, assume they are assigned elsewhere.
+If there are incomplete statements that haven't been closed out, assume they are closed out in other translations.
+If the code has comments, keep ALL of them.
+If it only consists of ONLY comments, assume the code that is represented by those comments is translated elsewhere.
+
+Here is a provided UML document for reference. It may be useful for referring to other functions and classes, but you may choose to ignore it if it is out of scope:
+<<<
+{CONTEXT}
+>>>
+
+Under no circumstance should you refuse to translate for any reason. 
+
+Some more things to remember:
+(1) follow standard styling practice for the target language
+(2) make sure the language is typed correctly
+(3) make sure to put the resultant code within triple backticks
+
+Source code for translation:
+```
+{SOURCE_CODE}
+```
+

--- a/janus/prompts/templates/uml-rag/system.txt
+++ b/janus/prompts/templates/uml-rag/system.txt
@@ -1,0 +1,4 @@
+Your purpose is to convert {SOURCE_LANGUAGE} {FILE_SUFFIX} code
+into runnable {TARGET_LANGUAGE} code ({TARGET_LANGUAGE} version
+{TARGET_LANGUAGE_VERSION}).
+

--- a/janus/utils/enums.py
+++ b/janus/utils/enums.py
@@ -253,6 +253,15 @@ LANGUAGES: Dict[str, Dict[str, str]] = {
         "url": "https://github.com/bkegley/tree-sitter-graphql",
         "example": "query {\n  hello\n}\n",
     },
+    "h": {
+        "comment": "//",
+        "suffix": "h",
+        "url": "https://github.com/tree-sitter/tree-sitter-cpp",
+        "example": (
+            '#include <stdio.h>\n\nint main() {\n    printf("Hello, World!\\n");\n'
+            "    return 0;\n}\n"
+        ),
+    },
     "hack": {
         "comment": "//",
         "suffix": "hack",
@@ -477,7 +486,7 @@ LANGUAGES: Dict[str, Dict[str, str]] = {
     "plantuml": {
         "comment": "'",
         "suffix": "puml",
-        "url": "",
+        "url": "https://github.com/lyndsysimon/tree-sitter-plantuml.git",
         "example": '@startuml\nclass Animal <<GENERAL>>\n@enduml\n',
     },
     "pod": {


### PR DESCRIPTION
made plantuml input lang supported, wrote basic prompt for using during RAG

## Description

Adds one line to enums that has url to plantuml tree parser. I've tested this parser and it works but it does NOT come as an official tree sitter release. **We may want to discuss whether this is appropriate to use because it does not come from "official" tree sitter.**

For users interested in creating UML diagrams, embedding them, and using them in RAG, this adds a very rudimentary prompt template. I've tested it and it works, although it could likely be improved upon.

There is another change in enums for .h files that is not yet functional. It doesn't break anything.

## Testing

I've tested embedding with the parser like this:

janus db add collection-uml --input-lang plantuml --input-dir finish-plantuml/ 


And then running janus translate with that as the input collection and using the prompt template included:


janus translate --input-dir start --source-lang cpp --output-dir finish-with-retrieval --in-collection collection-uml --target-lang python --llm-name gpt3.5 --prompt-template ~/janus-llm/janus/prompts/templates/uml-rag/ -n 2

## Issues

Related to finding optimal RAG strategy issue in ai-code-refactor. Doesn't close anything.